### PR TITLE
Add '-O' flag to curl example.

### DIFF
--- a/cmd/dm_web_admin/templates/file_info.html
+++ b/cmd/dm_web_admin/templates/file_info.html
@@ -17,6 +17,7 @@ On the command line, using cURL:
   <div class="card-body">
     <pre style="margin: 0">curl \
     --proxy {{.ProxyPublicAddress}} \
+    -O \
     '{{.File.Uri}}'</pre>
   </div>
 </div>


### PR DESCRIPTION
When downloading a binary file using the curl example shown on the file info page, curl will print an error instead of downloading the file:
```
Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
```

This adds the `-O` flag to save the file to disk instead of printing to the terminal.